### PR TITLE
Add docs branch type to validation workflow and README

### DIFF
--- a/.github/workflows/validate-branch-name.yml
+++ b/.github/workflows/validate-branch-name.yml
@@ -33,7 +33,7 @@ jobs:
             exit 0
           fi
 
-          if echo "$branch_name" | grep -Eq '^(feature|bugfix|hotfix|release|chore|refactor)/[a-z0-9._-]+$'; then
+          if echo "$branch_name" | grep -Eq '^(feature|bugfix|hotfix|release|chore|refactor|docs)/[a-z0-9._-]+$'; then
             echo "✅ Branch name is valid."
           else
             echo "❌ Invalid branch name: '$branch_name'"
@@ -50,6 +50,7 @@ jobs:
             echo "  - release/   → for preparing a release branch"
             echo "  - chore/     → for maintenance tasks (e.g., updating dependencies, configs)"
             echo "  - refactor/  → for code improvements without changing behavior"
+            echo "  - docs/      → for documentation updates only"
             echo ""
             echo "Description must contain lowercase letters, numbers, dashes (-), underscores (_), or dots (.)"
             echo ""

--- a/README.md
+++ b/README.md
@@ -82,6 +82,53 @@ Edit the `.env` file to configure:
 └── .env               # Environment variables (create from .env.example)
 ```
 
+## Development Workflow
+
+### Branch Naming Convention
+
+This project follows a standardized branch naming convention to maintain a clean and organized repository. When creating a new branch, please follow this pattern:
+
+```
+<type>/<description>
+```
+
+#### Branch Types
+
+- `feature/` - For new features or enhancements
+- `bugfix/` - For fixing non-critical bugs
+- `hotfix/` - For urgent production fixes
+- `release/` - For preparing release branches
+- `chore/` - For maintenance tasks (e.g., updating dependencies, configs)
+- `refactor/` - For code improvements without changing behavior
+- `docs/` - For documentation updates only
+
+#### Description Guidelines
+
+The description part should:
+- Use lowercase letters, numbers, dashes (-), underscores (_), or dots (.)
+- Be concise but descriptive
+- Use dashes (-) instead of spaces
+
+#### Examples
+
+```
+feature/add-login-api
+bugfix/fix-user-profile
+hotfix/security-patch
+release/v1.2.0
+chore/update-dependencies
+refactor/clean-auth-service
+docs/update-installation-guide
+```
+
+#### Protected Branches
+
+⚠️ **IMPORTANT**: Direct pushing to the following branches is not allowed:
+- `master` - Main production branch
+- `develop` - Development integration branch
+
+All changes to these protected branches must go through Pull Requests with proper code review.
+
 ## Safety & Ethics
 
 This tool is for educational purposes only. Be aware that:


### PR DESCRIPTION
This PR adds documentation branch type support:

### Changes:
- Added  branch type to the branch name validation GitHub Action
- Updated the README.md to document the new branch type
- Added an example for documentation branches

This ensures documentation-only changes can be properly categorized in our branch naming convention.